### PR TITLE
Add a retry flag to the tail command

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -38,4 +38,4 @@ if [ -n "${CONNECT_PORT}" ]; then
 fi
 
 tinyproxy -c /etc/tinyproxy.conf
-tail -f /var/log/tinyproxy/tinyproxy.log
+tail -f --retry /var/log/tinyproxy/tinyproxy.log


### PR DESCRIPTION
Currently, if the log file doesn't already exist when tail is called, the container will shut down since
the end of the boot script is reached.
The --retry flag allows tail to retry opening the log file indefinitely.
